### PR TITLE
macOS support

### DIFF
--- a/Makefile.common.header
+++ b/Makefile.common.header
@@ -154,7 +154,7 @@ _INCLUDENUMPY_FROM_PYTHON := $(COND_DARWIN)
 
 
 ifneq ($(_INCLUDENUMPY_FROM_PYTHON),)
-define _PYVARS_INCLUDENUMPY :=
+define _PYVARS_INCLUDENUMPY
 import numpy
 print(re.sub("[\t ]+", "__whitespace__", "_PY_INCLUDEPY+={}".format(numpy.get_include())))
 endef


### PR DESCRIPTION
This fixes two problems I encountered while trying to build `mrcal` on macOS. The echo lines in the footer Makefile has their indentation switched from spaces to tabs to be parsed as shell lines. Make also has an info command that might work instead. I also added automatic discovery for the `numpy` include path.